### PR TITLE
Add `tokenize_batch` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,18 @@ required-features = ["openai-vocabulary-file"]
 
 [dependencies]
 ahash = "0.8.6"
+ndarray = { version = "0.15.6", optional = true }
 regex = "1.10.2"
 
 [dev-dependencies]
 criterion = "0.5.1"
 
 [[bench]]
-name = "bench"
+name = "encode"
 required-features = ["openai-vocabulary-file"]
+harness = false
+
+[[bench]]
+name = "tokenize_batch"
+required-features = ["ndarray", "openai-vocabulary-file"]
 harness = false

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -53,5 +53,5 @@ fn long_sentence(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, short, realistic, long_word, long_sentence);
-criterion_main!(benches);
+criterion_group!(encode, short, realistic, long_word, long_sentence);
+criterion_main!(encode);

--- a/benches/tokenize_batch.rs
+++ b/benches/tokenize_batch.rs
@@ -1,0 +1,18 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use instant_clip_tokenizer::Tokenizer;
+
+fn small(c: &mut Criterion) {
+    let tokenizer = Tokenizer::new();
+    c.bench_function("small", |b| {
+        b.iter(|| {
+            tokenizer.tokenize_batch(
+                black_box(["Hi", "How are you?", "I'm fine, thanks!"]),
+                black_box(6),
+            )
+        })
+    });
+}
+
+criterion_group!(tokenize_batch, small);
+criterion_main!(tokenize_batch);


### PR DESCRIPTION
The Python bindings provide this method as a convenience function. I think this is useful for users of the Rust library as well, so I implemented it there. This means we have to take on a dependency on `ndarray`, but I think this is justified given how widely used this crate is in the ML ecosystem.