### PR TITLE
Add script to validate library correctness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,8 @@ test-python:
 	cargo build --release
 	cp target/release/libinstant_clip_tokenizer.dylib instant-clip-tokenizer-py/test/instant_clip_tokenizer.so
 	PYTHONPATH=instant-clip-tokenizer-py/test/ python3 -m test
+
+validate:
+	cargo build --release
+	cp target/release/libinstant_clip_tokenizer.dylib scripts/instant_clip_tokenizer.so
+	PYTHONPATH=scripts/ python3 -m validate scripts/Train_GCC-training.tsv

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+Train_GCC-training.tsv

--- a/scripts/original.py
+++ b/scripts/original.py
@@ -20,7 +20,7 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 @lru_cache
 def default_bpe():
     return os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "bpe_simple_vocab_16e6.txt"
+        os.path.dirname(os.path.abspath(__file__)), "../bpe_simple_vocab_16e6.txt"
     )
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,47 @@
+# Validate `instant-clip-tokenizer-py` by comparing its output with the original
+# tokenizer on a large dataset.
+#
+# This script requires one command line argument, the filename of the data file
+# to be used. The data file must be `.tsv` format with the strings to be used
+# for validation in the first column.
+#
+# It is recommended to use this with Google's Conceptual Captions dataset
+# (containing ~3.3M image captions), which can be downloaded here:
+# https://ai.google.com/research/ConceptualCaptions/download
+
+import html
+import sys
+
+import csv
+import ftfy
+import numpy as np
+
+import instant_clip_tokenizer
+import original
+
+
+def validate(filename):
+    tokenizer = instant_clip_tokenizer.Tokenizer()
+    with open(filename) as f:
+        rd = csv.reader(f, delimiter="\t", quotechar='"')
+        for row in rd:
+            text = row[0]
+            expected = original.tokenize(text)
+            ours = tokenizer.tokenize_batch(preprocess(text))
+            if not np.array_equal(ours, expected):
+                print(f"Failure: \"{text}\"")
+
+
+def preprocess(text):
+    # Copied from `basic_clean` function from `original.py`
+    text = ftfy.fix_text(text)
+    text = html.unescape(html.unescape(text))
+    return text.strip()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("validate.py must be called with exactly one argument - filename of data file", file=sys.stderr)
+        sys.exit(-1)
+
+    validate(sys.argv[1])


### PR DESCRIPTION
The script compares the tokenization output of our implementation agains the original Python library on Google's Conceptual Captions dataset (https://ai.google.com/research/ConceptualCaptions/ - around 3.3 million texts).

I chose that dataset because it contains texts that are representative of what the tokenizer is used for and is indeed one of the datasets that OpenCLIP was trained on. At the same time, it is not as gigantic as some of the other datasets and hence more manageable.

I ran this locally and found not a single issue in our code!

Closes #9 