### PR TITLE
Bump python version to 0.1.1

### DIFF
--- a/instant-clip-tokenizer-py/Cargo.toml
+++ b/instant-clip-tokenizer-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-clip-tokenizer-py"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
I'd like to publish a new version of the Python bindings so that we (and I:) get Intel-Mac support.